### PR TITLE
Set dynamic event store schema

### DIFF
--- a/lib/dynamic_cmd/commanded_application.ex
+++ b/lib/dynamic_cmd/commanded_application.ex
@@ -8,6 +8,10 @@ defmodule DynamicCmd.CMD do
     # Set dynamic event store name
     config = put_in(config, [:event_store, :name], Module.concat([name, EventStore]))
 
+    # Set the dynamic event store schema
+    schema_suffix = name |> Atom.to_string() |> String.replace("-", "")
+    config = put_in(config, [:event_store, :prefix], "cmd" <> schema_suffix)
+
     {:ok, config}
   end
 end


### PR DESCRIPTION
Commanded dynamic applications were designed to be used with their own event store. This PR demonstrates setting the Postgres event store schema dynamically and provisioning the schema before starting the application.

With the above changes the command dispatch timeout issue is resolved.